### PR TITLE
Remove extra filters and defer scripts

### DIFF
--- a/app.js
+++ b/app.js
@@ -30,19 +30,7 @@ document.addEventListener('DOMContentLoaded', async function () {
         L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png').addTo(map);
         let markersLayer = L.layerGroup().addTo(map);
 
-        const input = document.getElementById('filtroRapido');
-        input.addEventListener('input', () => {
-            const termo = input.value.toLowerCase();
-            const encontrado = allData.find(c => c.m.toLowerCase().includes(termo));
-            if (encontrado && encontrado.a && encontrado.o) {
-                markersLayer.clearLayers();
-                const marker = L.marker([encontrado.a, encontrado.o])
-                    .addTo(markersLayer)
-                    .bindPopup(`<strong>${encontrado.m}</strong>`)
-                    .openPopup();
-                map.setView([encontrado.a, encontrado.o], 12);
-            }
-        });
+        // Removido filtro rápido do mapa para simplificar a interface
 
         // Filtros adicionais podem ser implementados aqui no futuro
 

--- a/index.html
+++ b/index.html
@@ -96,25 +96,6 @@
     <div class="container mt-3">
         <div id="loader" style="text-align: center; padding: 10px; background-color: #dff9ff; color: #0d6efd;">Carregando dados...</div>
 
-<div class="container mb-3">
-  <div class="row g-2">
-    <div class="col-md">
-      <input id="filtroRapido" type="text" class="form-control" placeholder="🔍 Filtrar por cidade" />
-    </div>
-    <div class="col-md">
-      <input id="filtroPraca" type="text" class="form-control" placeholder="Praça" />
-    </div>
-    <div class="col-md">
-      <input id="filtroFilial" type="text" class="form-control" placeholder="Filial" />
-    </div>
-    <div class="col-md">
-      <input id="filtroData" type="date" class="form-control" />
-    </div>
-    <div class="col-md">
-      <input id="filtroRegiao" type="text" class="form-control" placeholder="Região" />
-    </div>
-  </div>
-</div>
 
 <div id="map"></div>
     </div>
@@ -196,28 +177,6 @@
 
         <!-- Resultados e Estatísticas -->
         
-<div class="row mb-3">
-    <div class="col-md-2">
-        <label for="filtroPraca" class="form-label">Praça:</label>
-        <input type="text" id="filtroPraca" class="form-control" placeholder="Digite a praça">
-    </div>
-    <div class="col-md-2">
-        <label for="filtroCidade" class="form-label">Cidade:</label>
-        <input type="text" id="filtroCidade" class="form-control" placeholder="Digite a cidade">
-    </div>
-    <div class="col-md-2">
-        <label for="filtroFilial" class="form-label">Filial:</label>
-        <input type="text" id="filtroFilial" class="form-control" placeholder="Digite a filial">
-    </div>
-    <div class="col-md-2">
-        <label for="filtroData" class="form-label">Data de Carregamento:</label>
-        <input type="date" id="filtroData" class="form-control">
-    </div>
-    <div class="col-md-2">
-        <label for="filtroRegiao" class="form-label">Região:</label>
-        <input type="text" id="filtroRegiao" class="form-control" placeholder="Digite a região">
-    </div>
-</div>
 
 <div class="row mb-3">
             <div class="col-md-12">
@@ -264,12 +223,12 @@
     </div>
 
     <!-- Bootstrap JS e Popper.js -->
-    <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js" defer></script>
     <!-- Script da aplicação -->
-    <script src="app.js"></script>
+    <script src="app.js" defer></script>
 
     <!-- Leaflet JS -->
-    <script src="https://unpkg.com/leaflet@1.9.4/dist/leaflet.js"></script>
+    <script src="https://unpkg.com/leaflet@1.9.4/dist/leaflet.js" defer></script>
 </body>
 
 </html>


### PR DESCRIPTION
## Summary
- remove extra filter inputs from HTML
- drop unused quick map filter from JS
- load scripts with `defer` for faster rendering

## Testing
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_685aa513c3708322909e9511ad9f365c